### PR TITLE
Tx helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,8 @@ import './test/chai';
 export {
     randomAddress,
 } from './utils/randomAddress';
+
+export {
+    executeTill,
+    executeFrom,
+} from './utils/stepByStep';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export {
     FlatTransactionComparable,
     compareTransaction,
     flattenTransaction,
+    findTransaction,
+    filterTransactions,
 } from './test/transaction';
 
 import './test/jest';

--- a/src/test/transaction.ts
+++ b/src/test/transaction.ts
@@ -136,3 +136,21 @@ export function compareTransactionForTest(subject: any, cmp: FlatTransactionComp
         }
     }
 }
+
+export const findTransaction = <T extends Transaction>(txs: T | T[], match: FlatTransactionComparable, required:boolean = true) => {
+    let res: T | undefined
+    if(Array.isArray(txs)) {
+        res = txs.find(x => compareTransaction(flattenTransaction(x), match))
+    }
+    else {
+        res = compareTransaction(flattenTransaction(txs), match) ? txs : undefined
+    }
+    if(required && res === undefined) {
+        throw(Error(`Expected ${inspect(Array.isArray(txs) ? txs.map(x => flattenTransaction(x)) : txs)} to contain a transaction that matches pattern ${inspect(match)}`))
+    }
+    return res
+}
+
+export const filterTransactions = <T extends Transaction> (txs: T[], match: FlatTransactionComparable) => {
+    return txs.filter(x => compareTransaction(flattenTransaction(x), match))
+}

--- a/src/test/transaction.ts
+++ b/src/test/transaction.ts
@@ -137,20 +137,24 @@ export function compareTransactionForTest(subject: any, cmp: FlatTransactionComp
     }
 }
 
-export const findTransaction = <T extends Transaction>(txs: T | T[], match: FlatTransactionComparable, required:boolean = true) => {
-    let res: T | undefined
-    if(Array.isArray(txs)) {
-        res = txs.find(x => compareTransaction(flattenTransaction(x), match))
+export function findTransaction<T extends Transaction>(txs: T | T[], match: FlatTransactionComparable) {
+    let res: T | undefined;
+    if (Array.isArray(txs)) {
+        res = txs.find(x => compareTransaction(flattenTransaction(x), match));
+    } else {
+        res = compareTransaction(flattenTransaction(txs), match) ? txs : undefined;
     }
-    else {
-        res = compareTransaction(flattenTransaction(txs), match) ? txs : undefined
-    }
-    if(required && res === undefined) {
-        throw(Error(`Expected ${inspect(Array.isArray(txs) ? txs.map(x => flattenTransaction(x)) : txs)} to contain a transaction that matches pattern ${inspect(match)}`))
-    }
-    return res
+    return res;
 }
 
-export const filterTransactions = <T extends Transaction> (txs: T[], match: FlatTransactionComparable) => {
-    return txs.filter(x => compareTransaction(flattenTransaction(x), match))
+export function findTransactionRequired<T extends Transaction>(txs: T | T[], match: FlatTransactionComparable) {
+    const res = findTransaction(txs, match);
+    if (res === undefined) {
+        throw new Error(`Expected ${inspect(Array.isArray(txs) ? txs.map(x => flattenTransaction(x)) : flattenTransaction(txs))} to contain a transaction that matches pattern ${inspect(match)}`);
+    }
+    return res;
+}
+
+export function filterTransactions<T extends Transaction>(txs: T[], match: FlatTransactionComparable) {
+    return txs.filter(x => compareTransaction(flattenTransaction(x), match));
 }

--- a/src/utils/stepByStep.ts
+++ b/src/utils/stepByStep.ts
@@ -2,33 +2,33 @@ import { Transaction } from "@ton/core";
 import { FlatTransactionComparable, flattenTransaction, compareTransaction } from "../test/transaction";
 import { inspect } from "node-inspect-extracted";
 
-export const executeTill = async <T extends Transaction>(txs: AsyncIterator<T>, match: FlatTransactionComparable) => {
-    let executed: T[] = []
-    let iterResult = await txs.next()
-    let found = false
-    while(!iterResult.done){
+export async function executeTill<T extends Transaction>(txs: AsyncIterator<T>, match: FlatTransactionComparable) {
+    let executed: T[] = [];
+    let iterResult = await txs.next();
+    let found = false;
+    while (!iterResult.done) {
         executed.push(iterResult.value);
         found = compareTransaction(flattenTransaction(iterResult.value), match);
-        if(found) {
-            break
+        if (found) {
+            break;
         }
-        iterResult = await txs.next()
+        iterResult = await txs.next();
     }
-    if(!found) {
-        throw(Error(`Expected ${inspect(executed.map(x => flattenTransaction(x)))} to contain a transaction that matches pattern ${inspect(match)}`))
+    if (!found) {
+        throw new Error(`Expected ${inspect(executed.map(x => flattenTransaction(x)))} to contain a transaction that matches pattern ${inspect(match)}`);
     }
 
-    return executed
+    return executed;
 }
 
-export const executeFrom = async <T extends Transaction>(txs: AsyncIterator<T>) => {
-    let executed: T[] = []
-    let iterResult = await txs.next()
+export async function executeFrom<T extends Transaction>(txs: AsyncIterator<T>) {
+    let executed: T[] = [];
+    let iterResult = await txs.next();
 
-    while(!iterResult.done) {
-        executed.push(iterResult.value)
-        iterResult = await txs.next()
+    while (!iterResult.done) {
+        executed.push(iterResult.value);
+        iterResult = await txs.next();
     }
 
-    return executed
+    return executed;
 }

--- a/src/utils/stepByStep.ts
+++ b/src/utils/stepByStep.ts
@@ -1,0 +1,34 @@
+import { Transaction } from "@ton/core";
+import { FlatTransactionComparable, flattenTransaction, compareTransaction } from "../test/transaction";
+import { inspect } from "node-inspect-extracted";
+
+export const executeTill = async <T extends Transaction>(txs: AsyncIterator<T>, match: FlatTransactionComparable) => {
+    let executed: T[] = []
+    let iterResult = await txs.next()
+    let found = false
+    while(!iterResult.done){
+        executed.push(iterResult.value);
+        found = compareTransaction(flattenTransaction(iterResult.value), match);
+        if(found) {
+            break
+        }
+        iterResult = await txs.next()
+    }
+    if(!found) {
+        throw(Error(`Expected ${inspect(executed.map(x => flattenTransaction(x)))} to contain a transaction that matches pattern ${inspect(match)}`))
+    }
+
+    return executed
+}
+
+export const executeFrom = async <T extends Transaction>(txs: AsyncIterator<T>) => {
+    let executed: T[] = []
+    let iterResult = await txs.next()
+
+    while(!iterResult.done) {
+        executed.push(iterResult.value)
+        iterResult = await txs.next()
+    }
+
+    return executed
+}


### PR DESCRIPTION
# More helpers

## Finding helpers

### findTransaction

Returns matching transaction.

By default, If not found, throws error in format of `toHaveTransaction`.
If `requred` flag is set to false, returns `undefined`

### filterTransactions

Returns array of matching transactions 

## Step by step execution helpers

### executeTill

Executes transactions iterator till matching transaction.
If none matched, throws error in format of `toHaveTransaction`.

Returns array of executed transactions.

### executeFrom

Executes transactions iterator till end of transactions chain.

Returns array of executed transactions.

