### PR TITLE
Add toApproxGasUsage expect helper

### DIFF
--- a/src/test/comparisons.ts
+++ b/src/test/comparisons.ts
@@ -1,4 +1,4 @@
-import { Address, Cell, Slice } from "@ton/core";
+import { Address, Cell, Slice, Transaction } from "@ton/core";
 import { CompareResult } from "./interface";
 
 export function compareCellForTest(subject: any, cmp: Cell): CompareResult {
@@ -22,5 +22,35 @@ export function compareSliceForTest(subject: any, cmp: Slice): CompareResult {
         pass: cmp.asCell().equals(subject.asCell()),
         posMessage: ((subject: any, cmp: Slice) => `Expected\n${subject}\nto equal\n${cmp}`).bind(undefined, subject, cmp),
         negMessage: ((subject: any, cmp: Slice) => `Expected\n${subject}\nNOT to equal\n${cmp}\nbut it does`).bind(undefined, subject, cmp),
+    }
+}
+
+
+export function gasUsage(messageResult: any): bigint {
+    try {
+        const transactions = Array.isArray(messageResult?.transactions) ? messageResult.transactions : (Array.isArray(messageResult) ? messageResult : [messageResult]);
+        return transactions.reduce((gas: bigint, tx: Transaction) => {
+            return gas + tx.totalFees.coins;
+        }, 0n)
+    } catch (e) {
+        throw new Error("Compared object is not SendMessageResult nor transaction(s)");
+    }
+}
+
+export function gasCompare(messageResult: any, toCompare: bigint, accuracy: bigint = 2n): [bigint, boolean] {
+    const gas = gasUsage(messageResult);
+    if (gas >= toCompare - accuracy) {
+        if (gas <= toCompare + accuracy) {
+            return [gas, true];
+        }
+    }
+    return [gas, false];
+}
+export function gasUsageForTest(subject: any, cmp: bigint, accuracy: bigint = 2n): CompareResult {
+    const [gas, pass] = gasCompare(subject, cmp, accuracy);
+    return {
+        pass,
+        posMessage: ((subject: any, cmp: bigint, accuracy?: bigint) => `Expected ${gas} to equal ${cmp}${accuracy === 0n ? '' : `±${accuracy}`}`).bind(undefined, subject, cmp, accuracy),
+        negMessage: ((subject: any, cmp: bigint, accuracy?: bigint) => `Expected ${gas} NOT to equal ${cmp}${accuracy === 0n ? '' : `±${accuracy}`} but it does`).bind(undefined, subject, cmp, accuracy),
     }
 }

--- a/src/test/jest.ts
+++ b/src/test/jest.ts
@@ -1,12 +1,17 @@
 import { FlatTransactionComparable, compareTransactionForTest } from "./transaction";
 import type { MatcherFunction } from "expect";
 import { CompareResult } from "./interface";
-import { compareAddressForTest, compareCellForTest, compareSliceForTest } from "./comparisons";
+import {
+    compareAddressForTest,
+    compareCellForTest,
+    compareSliceForTest,
+    gasUsageForTest
+} from "./comparisons";
 import { Address, Cell, Slice } from "@ton/core";
 
-function wrapComparer<T>(comparer: (subject: any, cmp: T) => CompareResult): MatcherFunction<[cmp: T]> {
-    return function(actual, cmp) {
-        const result = comparer(actual, cmp)
+function wrapComparer<T>(comparer: (subject: any, cmp: T, ...rest: Array<any>) => CompareResult): MatcherFunction<[cmp: T]> {
+    return function(actual, cmp, ...rest) {
+        const result = comparer(actual, cmp, ...rest)
         return {
             pass: result.pass,
             message: () => {
@@ -24,6 +29,7 @@ const toHaveTransaction = wrapComparer(compareTransactionForTest)
 const toEqualCell = wrapComparer(compareCellForTest)
 const toEqualAddress = wrapComparer(compareAddressForTest)
 const toEqualSlice = wrapComparer(compareSliceForTest)
+const toApproxGasUsage = wrapComparer(gasUsageForTest)
 
 try {
     const jestGlobals = require("@jest/globals");
@@ -33,6 +39,7 @@ try {
         toEqualCell,
         toEqualAddress,
         toEqualSlice,
+        toApproxGasUsage,
     })
 } catch (e) {}
 
@@ -43,6 +50,7 @@ declare global {
             toEqualCell(cell: Cell): R
             toEqualAddress(address: Address): R
             toEqualSlice(slice: Slice): R
+            toApproxGasUsage(gasUsage: bigint, accuracy?: bigint): R
         }
     }
 }


### PR DESCRIPTION
# More helpers
## Gas usage helper
### toApproxGasUsage

Usage example:
```ts
const smr: SendMessageResult = await act("some send message act");

// with SendMessageResult
expect(smr).toApproxGasUsage(1000000n, 10n);

// with Transactions list
expect(smr.transactions).toApproxGasUsage(1000000n);

// with one Transaction
expect(smr.transactions[0]).toApproxGasUsage(1000000n, 0n);
```

## Motivation

To be able compare gas usage with previous version of code

