### PR TITLE
Feat: Add support for Bun test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **feat**: Add support for the Bun.js test runner.
+
+### Changed
+- **docs**: Updated `README.md` with examples and instructions for using the Bun matchers.
+
 ## [0.7.0] - 2025-06-02
 
 - Add address, opcode and errors description in `toHaveTransaction` method

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # test-utils
 
-This package contains useful testing utilities, such as unit test matchers (for jest and chai) and other useful functions, such as `randomAddress`.
+This package contains useful testing utilities, such as unit test matchers (for jest, chai, and bun) and other useful functions, such as `randomAddress`.
 
 ## Installation
 
@@ -14,9 +14,41 @@ npm i --save-dev @ton/test-utils
 
 ## Usage
 
-To use the test matchers, just install either jest or chai and import this package like so:
+To use the test matchers, just install either jest, chai, or bun and import this package like so:
 ```typescript
 import "@ton/test-utils";
+```
+
+### Examples
+
+#### Jest
+```typescript
+import { expect } from '@jest/globals';
+import "@ton/test-utils";
+
+test('cell comparison', () => {
+    expect(cell1).toEqualCell(cell2);
+});
+```
+
+#### Chai
+```typescript
+import { expect } from 'chai';
+import "@ton/test-utils";
+
+it('cell comparison', () => {
+    expect(cell1).to.equalCell(cell2);
+});
+```
+
+#### Bun
+```typescript
+import { expect, test } from 'bun:test';
+import "@ton/test-utils";
+
+test('cell comparison', () => {
+    expect(cell1).toEqualCell(cell2);
+});
 ```
 
 ### Transaction matcher notice

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ton/toolchain": "the-ton-tech/toolchain#v1.4.0",
     "@types/chai": "^4.3.4",
     "@types/jest": "^29.4.4",
+    "bun-types": "^1.0.0",
     "chai": "^4.3.7",
     "eslint": "^9.28.0",
     "jest": "^29.5.0",
@@ -28,10 +29,14 @@
   "peerDependencies": {
     "@jest/globals": "*",
     "@ton/core": ">=0.49.2",
+    "bun-types": "*",
     "chai": "*"
   },
   "peerDependenciesMeta": {
     "@jest/globals": {
+      "optional": true
+    },
+    "bun-types": {
       "optional": true
     },
     "chai": {
@@ -46,6 +51,7 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --max-warnings 0 --fix",
     "test": "jest",
+    "test:bun": "bun test",
     "build": "rm -rf dist && tsc"
   },
   "packageManager": "yarn@3.6.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { contractsMeta, ContractsMeta } from './utils/ContractsMeta';
 
 import './test/jest';
 import './test/chai';
+import './test/bun';
 
 export { prettifyTransaction, PrettyTransaction } from './utils/pretty-transaction';
 

--- a/src/test/bun.ts
+++ b/src/test/bun.ts
@@ -1,0 +1,54 @@
+import type { MatcherFunction } from 'expect';
+import { Address, Cell, Slice } from '@ton/core';
+
+import { FlatTransactionComparable, compareTransactionForTest } from './transaction';
+import { CompareResult } from './interface';
+import { compareAddressForTest, compareCellForTest, compareSliceForTest } from './comparisons';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function wrapComparer<T>(comparer: (subject: any, cmp: T) => CompareResult): MatcherFunction<[cmp: T]> {
+    return function (actual, cmp) {
+        const result = comparer(actual, cmp);
+        return {
+            pass: result.pass,
+            message: () => {
+                if (result.pass) {
+                    return result.negMessage();
+                } else {
+                    return result.posMessage();
+                }
+            },
+        };
+    };
+}
+
+const toHaveTransaction = wrapComparer(compareTransactionForTest);
+const toEqualCell = wrapComparer(compareCellForTest);
+const toEqualAddress = wrapComparer(compareAddressForTest);
+const toEqualSlice = wrapComparer(compareSliceForTest);
+
+try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const bunTest = require('bun:test');
+
+    if (bunTest && bunTest.expect)
+        bunTest.expect.extend({
+            toHaveTransaction,
+            toEqualCell,
+            toEqualAddress,
+            toEqualSlice,
+        });
+    // eslint-disable-next-line no-empty
+} catch (_) {}
+
+interface TonMatchers<T> {
+    toHaveTransaction(cmp: FlatTransactionComparable): T;
+    toEqualCell(cell: Cell): T;
+    toEqualAddress(address: Address): T;
+    toEqualSlice(slice: Slice): T;
+}
+
+// @ts-ignore: Module 'bun:test' is only available in bun environment
+declare module 'bun:test' {
+    interface Matchers<T> extends TonMatchers<T> {}
+}

--- a/src/test/bun.ts
+++ b/src/test/bun.ts
@@ -48,7 +48,8 @@ interface TonMatchers<T> {
     toEqualSlice(slice: Slice): T;
 }
 
-// @ts-ignore: Module 'bun:test' is only available in bun environment
+// @ts-expect-error: Module 'bun:test' is only available in bun environment
 declare module 'bun:test' {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     interface Matchers<T> extends TonMatchers<T> {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,6 +1017,7 @@ __metadata:
     "@ton/toolchain": "the-ton-tech/toolchain#v1.4.0"
     "@types/chai": ^4.3.4
     "@types/jest": ^29.4.4
+    bun-types: ^1.0.0
     chai: ^4.3.7
     eslint: ^9.28.0
     jest: ^29.5.0
@@ -1026,9 +1027,12 @@ __metadata:
   peerDependencies:
     "@jest/globals": "*"
     "@ton/core": ">=0.49.2"
+    bun-types: "*"
     chai: "*"
   peerDependenciesMeta:
     "@jest/globals":
+      optional: true
+    bun-types:
       optional: true
     chai:
       optional: true
@@ -1769,6 +1773,15 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"bun-types@npm:^1.0.0":
+  version: 1.2.15
+  resolution: "bun-types@npm:1.2.15"
+  dependencies:
+    "@types/node": "*"
+  checksum: 33f55e374332281b7d73b28f75c82d97a3c3d9e942281d143697e2d96636650b24954c5048a20ce0d312a432506445fa938d28e58d8748d72b4c8bad086d2b77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
This pull request introduces support for the Bun test runner, allowing developers to use this library's custom matchers in their Bun-based projects.
The implementation is consistent with the existing setup for Jest and Chai, using expect.extend() to provide matchers like toHaveTransaction, toEqualCell, and more.
## Key Changes:
* Bun Support: A new src/test/bun.ts file has been added to integrate with Bun's test framework.
* Configuration: package.json has been updated to include bun-types as an optional dependency and a test:bun script for convenience.
* Documentation: The README.md is updated with clear examples and instructions for using the matchers with Bun.