### PR TITLE
Enable Ton matchers in TypeScript when using `expect` from `@jest/globals`

### DIFF
--- a/src/test/jest.ts
+++ b/src/test/jest.ts
@@ -1,3 +1,4 @@
+import 'expect';
 import type { MatcherFunction } from 'expect';
 import { Address, Cell, Slice } from '@ton/core';
 
@@ -52,20 +53,28 @@ try {
     // eslint-disable-next-line no-empty
 } catch (_) {}
 
+interface TonMatchers<R> {
+    toHaveTransaction(cmp: FlatTransactionComparable): R;
+    toEqualCell(cell: Cell): R;
+    toEqualAddress(address: Address): R;
+    toEqualSlice(slice: Slice): R;
+
+    /**
+     * @example
+     * await expect(() => blockchain.runGetMethod(contract.address, 'test')).toThrowExitCode(11);
+     */
+    toThrowExitCode(exitCode: number): Promise<R>;
+}
+
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     export namespace jest {
-        interface Matchers<R> {
-            toHaveTransaction(cmp: FlatTransactionComparable): R;
-            toEqualCell(cell: Cell): R;
-            toEqualAddress(address: Address): R;
-            toEqualSlice(slice: Slice): R;
-
-            /**
-             * @example
-             * await expect(() => blockchain.runGetMethod(contract.address, 'test')).toThrowExitCode(11);
-             */
-            toThrowExitCode(exitCode: number): Promise<R>;
-        }
+        interface Matchers<R> extends TonMatchers<R> {}
     }
+}
+
+declare module 'expect' {
+    interface Matchers<R> extends TonMatchers<R> {}
 }


### PR DESCRIPTION
Ton custom matchers like `toHaveTransaction` were previously only available when using the global `expect`. This PR adds full TypeScript support for projects that import `expect` explicitly from `@jest/globals`.

## Changes

* Introduced a `TonMatchers<R>` interface to avoid duplication.
* Augmented both:
  * Global `jest.Matchers<R>` (for traditional global usage).
  * Module `@jest/expect`'s `Matchers<R>` (for explicit `expect` imports).
* Ensured module augmentation is triggered by importing `'expect'`.
* No runtime changes; this is a pure typings enhancement.

## Motivation

Modern Jest usage, especially in TypeScript projects, often relies on explicit imports like:

```ts
import { expect } from '@jest/globals';
```

Without this update, consumers lose type safety for Ton-specific matchers unless they use the global `expect`, which can lead to confusion or unnecessary workarounds.

## Benefits

* Enables proper typings for Ton matchers when using `expect` via `@jest/globals`.
* Improves developer experience and consistency across test styles.
* Avoids the need for local patches, manual module augmentation, or `as any` casts.

## Checklist

- [x] All tests pass successfully (`yarn test`)
- [x] Code passes linting checks (`yarn lint`)
